### PR TITLE
Improvements

### DIFF
--- a/Sources/Pathspec/GitIgnoreSpec.swift
+++ b/Sources/Pathspec/GitIgnoreSpec.swift
@@ -16,9 +16,13 @@ struct GitIgnoreSpec: Spec {
     }
 
 	private(set) var inclusive: Bool = true
+
+    let pattern: String
 	let regex: NSRegularExpression
 
     init(pattern: String) throws {
+        self.pattern = pattern
+
         guard !pattern.isEmpty else { throw Error.emptyPattern }
 		guard !pattern.hasPrefix("#") else { throw Error.containsPoundPrefix }
 		guard !pattern.contains("***") else { throw Error.containsTrippleStar }
@@ -154,4 +158,19 @@ struct GitIgnoreSpec: Spec {
 		
 		return regex
 	}
+}
+
+extension GitIgnoreSpec: CustomStringConvertible {
+    var description: String {
+        let pattern = self.pattern.debugDescription
+        return "<\(type(of: self)) pattern: \(pattern)>"
+    }
+}
+
+extension GitIgnoreSpec: CustomDebugStringConvertible {
+    var debugDescription: String {
+        let pattern = self.pattern.debugDescription
+        let regexPattern = self.regex.pattern.debugDescription
+        return "<\(type(of: self)) pattern: \(pattern) regex: \(regexPattern)>"
+    }
 }

--- a/Sources/Pathspec/GitIgnoreSpec.swift
+++ b/Sources/Pathspec/GitIgnoreSpec.swift
@@ -10,8 +10,8 @@ import Foundation
 struct GitIgnoreSpec: Spec {
     enum Error: Swift.Error {
         case emptyPattern
-        case containsPoundPrefix
-        case containsTrippleStar
+        case commented
+        case invalid
         case emptyRoot
     }
 
@@ -24,9 +24,9 @@ struct GitIgnoreSpec: Spec {
         self.pattern = pattern
 
         guard !pattern.isEmpty else { throw Error.emptyPattern }
-		guard !pattern.hasPrefix("#") else { throw Error.containsPoundPrefix }
-		guard !pattern.contains("***") else { throw Error.containsTrippleStar }
-		guard pattern != "/" else { throw Error.emptyPattern }
+		guard !pattern.hasPrefix("#") else { throw Error.commented }
+		guard !pattern.contains("***") else { throw Error.invalid }
+		guard pattern != "/" else { throw Error.emptyRoot }
 		
 		var pattern = pattern
 		if pattern.hasPrefix("!") {

--- a/Sources/Pathspec/GitIgnoreSpec.swift
+++ b/Sources/Pathspec/GitIgnoreSpec.swift
@@ -8,14 +8,21 @@
 import Foundation
 
 struct GitIgnoreSpec: Spec {
+    enum Error: Swift.Error {
+        case emptyPattern
+        case containsPoundPrefix
+        case containsTrippleStar
+        case emptyRoot
+    }
+
 	private(set) var inclusive: Bool = true
 	let regex: NSRegularExpression
-	
-	init?(pattern: String) {
-		guard !pattern.isEmpty else { return nil }
-		guard !pattern.hasPrefix("#") else { return nil }
-		guard !pattern.contains("***") else { return nil }
-		guard pattern != "/" else { return nil }
+
+    init(pattern: String) throws {
+        guard !pattern.isEmpty else { throw Error.emptyPattern }
+		guard !pattern.hasPrefix("#") else { throw Error.containsPoundPrefix }
+		guard !pattern.contains("***") else { throw Error.containsTrippleStar }
+		guard pattern != "/" else { throw Error.emptyPattern }
 		
 		var pattern = pattern
 		if pattern.hasPrefix("!") {
@@ -81,11 +88,7 @@ struct GitIgnoreSpec: Spec {
 		
 		regexString += "$"
 		
-		do {
-			regex = try NSRegularExpression(pattern: regexString, options: [])
-		} catch {
-			return nil
-		}
+		regex = try NSRegularExpression(pattern: regexString, options: [])
 	}
 	
 	func match(file: String) -> Bool {

--- a/Sources/Pathspec/Pathspec.swift
+++ b/Sources/Pathspec/Pathspec.swift
@@ -8,11 +8,15 @@
 public final class Pathspec {
 	private let specs: [Spec]
 	
-	public init(patterns: [String]) {
-		specs = patterns.compactMap {
-			GitIgnoreSpec(pattern: $0)
-		}
+	public convenience init(patterns: [String]) throws {
+		self.init(specs: try patterns.map {
+            try GitIgnoreSpec(pattern: $0)
+        })
 	}
+
+    public init(specs: [Spec]) {
+        self.specs = specs
+    }
 	
 	public func match(path: String) -> Bool {
 		let matchingSpecs = self.matchingSpecs(path: path)
@@ -29,6 +33,8 @@ extension Pathspec: ExpressibleByArrayLiteral {
     public typealias ArrayLiteralElement = String
 
     public convenience init(arrayLiteral: String...) {
-        self.init(patterns: arrayLiteral)
+        self.init(specs: arrayLiteral.compactMap {
+            try? GitIgnoreSpec(pattern: $0)
+        })
     }
 }

--- a/Sources/Pathspec/Pathspec.swift
+++ b/Sources/Pathspec/Pathspec.swift
@@ -38,3 +38,21 @@ extension Pathspec: ExpressibleByArrayLiteral {
         })
     }
 }
+
+extension Pathspec: CustomStringConvertible {
+    public var description: String {
+        let specsDescription = specs.map { spec in
+            "  " + String(describing: spec)
+        }.joined(separator: ",\n")
+        return "<\(type(of: self)) specs: [\n\(specsDescription)\n]>"
+    }
+}
+
+extension Pathspec: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        let specsDescription = specs.map { spec in
+            "  " + String(reflecting: spec)
+        }.joined(separator: ",\n")
+        return "<\(type(of: self)) specs: [\n\(specsDescription)\n]>"
+    }
+}

--- a/Sources/Pathspec/Pathspec.swift
+++ b/Sources/Pathspec/Pathspec.swift
@@ -8,7 +8,7 @@
 public final class Pathspec {
 	private let specs: [Spec]
 	
-	public init(patterns: String...) {
+	public init(patterns: [String]) {
 		specs = patterns.compactMap {
 			GitIgnoreSpec(pattern: $0)
 		}
@@ -23,4 +23,12 @@ public final class Pathspec {
 	private func matchingSpecs(path: String) -> [Spec] {
 		return specs.filter { $0.match(file: path) }
 	}
+}
+
+extension Pathspec: ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = String
+
+    public convenience init(arrayLiteral: String...) {
+        self.init(patterns: arrayLiteral)
+    }
 }

--- a/Tests/PathspecTests/GitIgnoreSpecTests.swift
+++ b/Tests/PathspecTests/GitIgnoreSpecTests.swift
@@ -8,21 +8,6 @@
 import XCTest
 @testable import Pathspec
 
-#if swift(<5.1)
-private struct UnwrappingFailure: LocalizedError {
-	var errorDescription: String? {
-		return "XCTUnwrap failed: throwing an unknown exception"
-	}
-}
-public func XCTUnwrap<T>(_ expression: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) throws -> T {
-	guard let unwrapped = try expression() else {
-		XCTFail(message(), file: file, line: line)
-		throw UnwrappingFailure()
-	}
-	return unwrapped
-}
-#endif
-
 final class GitIgnoreSpecTests: XCTestCase {
 	func testDescription() throws {
         let spec = try XCTUnwrap(GitIgnoreSpec(pattern: "foobar"))

--- a/Tests/PathspecTests/GitIgnoreSpecTests.swift
+++ b/Tests/PathspecTests/GitIgnoreSpecTests.swift
@@ -23,7 +23,7 @@ public func XCTUnwrap<T>(_ expression: @autoclosure () throws -> T?, _ message: 
 }
 #endif
 
-final class PathspecTests: XCTestCase {
+final class GitIgnoreSpecTests: XCTestCase {
 	func testDescription() throws {
         let spec = try XCTUnwrap(GitIgnoreSpec(pattern: "foobar"))
 

--- a/Tests/PathspecTests/PathspecTests.swift
+++ b/Tests/PathspecTests/PathspecTests.swift
@@ -25,11 +25,11 @@ public func XCTUnwrap<T>(_ expression: @autoclosure () throws -> T?, _ message: 
 
 final class PathspecTests: XCTestCase {
 	func testAbsoluteRoot() throws {
-		XCTAssertNil(GitIgnoreSpec(pattern: "/"))
+		XCTAssertThrowsError(try GitIgnoreSpec(pattern: "/"))
 	}
 	
 	func testComment() throws {
-		XCTAssertNil(GitIgnoreSpec(pattern: "# Cork soakers."))
+        XCTAssertThrowsError(try GitIgnoreSpec(pattern: "# Cork soakers."))
 	}
 	
 	func testIgnore() throws {
@@ -255,8 +255,8 @@ final class PathspecTests: XCTestCase {
 		)
 	}
 	
-	func testFailingInitializers() {
-		XCTAssertNil(GitIgnoreSpec(pattern: ""))
-		XCTAssertNil(GitIgnoreSpec(pattern: "***"))
+	func testFailingInitializers() throws {
+		XCTAssertThrowsError(try GitIgnoreSpec(pattern: ""))
+		XCTAssertThrowsError(try GitIgnoreSpec(pattern: "***"))
 	}
 }

--- a/Tests/PathspecTests/PathspecTests.swift
+++ b/Tests/PathspecTests/PathspecTests.swift
@@ -24,7 +24,19 @@ public func XCTUnwrap<T>(_ expression: @autoclosure () throws -> T?, _ message: 
 #endif
 
 final class PathspecTests: XCTestCase {
-	func testAbsoluteRoot() throws {
+	func testDescription() throws {
+        let spec = try XCTUnwrap(GitIgnoreSpec(pattern: "foobar"))
+
+        XCTAssertEqual(spec.description, "<GitIgnoreSpec pattern: \"foobar\">")
+    }
+
+    func testDebugDescription() throws {
+        let spec = try XCTUnwrap(GitIgnoreSpec(pattern: "foobar"))
+
+        XCTAssertEqual(spec.debugDescription, "<GitIgnoreSpec pattern: \"foobar\" regex: \"^(?:.+/)?foobar(?:/.*)?$\">")
+    }
+
+    func testAbsoluteRoot() throws {
 		XCTAssertThrowsError(try GitIgnoreSpec(pattern: "/"))
 	}
 	

--- a/Tests/PathspecTests/PathspecTests.swift
+++ b/Tests/PathspecTests/PathspecTests.swift
@@ -1,0 +1,39 @@
+//
+//  File.swift
+//  
+//
+//  Created by Vincent Esche on 4/23/20.
+//
+
+import XCTest
+@testable import Pathspec
+
+final class PathspecTests: XCTestCase {
+    func testDescription() throws {
+        let spec: Pathspec = try XCTUnwrap(["foo", "foo/bar"])
+
+        XCTAssertEqual(
+            spec.description,
+            """
+            <Pathspec specs: [
+              <GitIgnoreSpec pattern: "foo">,
+              <GitIgnoreSpec pattern: "foo/bar">
+            ]>
+            """
+        )
+    }
+
+    func testDebugDescription() throws {
+        let spec: Pathspec = try XCTUnwrap(["foo", "foo/bar"])
+
+        XCTAssertEqual(
+            spec.debugDescription,
+            """
+            <Pathspec specs: [
+              <GitIgnoreSpec pattern: "foo" regex: "^(?:.+/)?foo(?:/.*)?$">,
+              <GitIgnoreSpec pattern: "foo/bar" regex: "^foo/bar(?:/.*)?$">
+            ]>
+            """
+        )
+    }
+}

--- a/Tests/PathspecTests/XCTUnwrap.swift
+++ b/Tests/PathspecTests/XCTUnwrap.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//  
+//
+//  Created by Vincent Esche on 4/23/20.
+//
+
+import XCTest
+@testable import Pathspec
+
+#if swift(<5.1)
+private struct UnwrappingFailure: LocalizedError {
+    var errorDescription: String? {
+        return "XCTUnwrap failed: throwing an unknown exception"
+    }
+}
+public func XCTUnwrap<T>(_ expression: @autoclosure () throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) throws -> T {
+    guard let unwrapped = try expression() else {
+        XCTFail(message(), file: file, line: line)
+        throw UnwrappingFailure()
+    }
+    return unwrapped
+}
+#endif


### PR DESCRIPTION
The current implementations makes use of `init?`, which silently swallows pattern errors.

As such Pathspec currently makes it needlessly hard to figure out why a path is dropped on `init(patterns:)`.

While a throwing `init` can trivially be turned into an ad-hoc `init?` by use of `try?` the reverse is not possible.